### PR TITLE
Fix iconv dependency to use only major version 2 of iconv

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/TooTallNate/ref-wchar",
   "dependencies": {
-    "iconv": "~2.1.10",
+    "iconv": "2",
     "ref": "^1.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes issue https://github.com/TooTallNate/ref-wchar/issues/3 and was tested on Linux (Ubuntu, Debian and Arch) using an npm-shrinkwrap.json before.
