### PR TITLE
Update appveyor.xml to use node 6 as build target

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,11 @@ environment:
     - nodejs_version: "0.8"
     - nodejs_version: "0.10"
     - nodejs_version: "0.12"
-    # io.js
     - nodejs_version: "2"
     - nodejs_version: "3.2"
     - nodejs_version: "4"
     - nodejs_version: "5"
+    - nodejs_version: "6"
 
 platform:
   - x86


### PR DESCRIPTION
Update appveyor.xml to use node 6 as build target. This is necessary since node v6+ is already out and in the wild and node.js versions are not io.js anymore.
