### PR TITLE
Update travis.yml to use node version 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ node_js:
   - "3.2"
   - "4"
   - "5"
+  - "6"
 
 install:
   - PATH="`npm bin`:`npm bin -g`:$PATH"


### PR DESCRIPTION
Sorry, I didn't recognize the travis.yml file at first. This is to use node 6 also in travis, not only on appveyor.
